### PR TITLE
Fix uppercase bug (issue 63)

### DIFF
--- a/org.kevoree.modeling.kotlin.generator/src/main/java/org/kevoree/modeling/kotlin/generator/GenerationContext.java
+++ b/org.kevoree.modeling.kotlin.generator/src/main/java/org/kevoree/modeling/kotlin/generator/GenerationContext.java
@@ -184,7 +184,7 @@ public class GenerationContext {
 
     public void setBaseLocationForUtilitiesGeneration(String targetName) throws Exception {
         basePackageForUtilitiesGeneration = targetName.toLowerCase();
-        baseLocationForUtilitiesGeneration = new File((rootGenerationDirectory.getAbsolutePath() + File.separator + basePackageForUtilitiesGeneration.replace(".", File.separator)).toLowerCase());
+        baseLocationForUtilitiesGeneration = new File((rootGenerationDirectory.getAbsolutePath() + File.separator + basePackageForUtilitiesGeneration.replace(".", File.separator)));
         metaModelName = targetName;
         if (targetName.contains(".")) {
             formattedName = targetName.substring(targetName.lastIndexOf(".") + 1);

--- a/org.kevoree.modeling.kotlin.generator/src/main/java/org/kevoree/modeling/kotlin/generator/ProcessorHelper.java
+++ b/org.kevoree.modeling.kotlin.generator/src/main/java/org/kevoree/modeling/kotlin/generator/ProcessorHelper.java
@@ -386,7 +386,7 @@ public class ProcessorHelper {
     public String getPackageGenDir(GenerationContext ctx, EPackage pack) {
         String modelGenBaseDir = ctx.rootGenerationDirectory.getAbsolutePath() + "/";
         modelGenBaseDir += fqn(pack).replace(".", "/") + "/";
-        return modelGenBaseDir.toLowerCase();
+        return modelGenBaseDir;
     }
 
     /**


### PR DESCRIPTION
Quick fix to keep the uppercase letters in the path for the generation of Kotlin classes.
It was only tested on my (linux) computer.

See https://github.com/dukeboard/kevoree-modeling-framework/issues/63 for further details about the bug.
